### PR TITLE
feat: add some 3rd-party tests

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -35,6 +35,7 @@ on:
           - prettier-plugin-svelte
           - rollup-plugin-svelte
           - skeleton
+          - svelte-eslint-parser
           - svelte-loader
           - svelte-preprocess
           - sveltekit
@@ -105,6 +106,7 @@ jobs:
           - prettier-plugin-svelte
           - rollup-plugin-svelte
           - skeleton
+          - svelte-eslint-parser
           - svelte-loader
           - svelte-preprocess
           - sveltekit

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -31,8 +31,10 @@ on:
           - "-"
           - eslint-plugin-svelte
           - language-tools
+          - mdsvex
           - prettier-plugin-svelte
           - rollup-plugin-svelte
+          - skeleton
           - svelte-loader
           - svelte-preprocess
           - sveltekit
@@ -99,8 +101,10 @@ jobs:
         suite:
           - eslint-plugin-svelte
           - language-tools
+          - mdsvex
           - prettier-plugin-svelte
           - rollup-plugin-svelte
+          - skeleton
           - svelte-loader
           - svelte-preprocess
           - sveltekit

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -36,8 +36,10 @@ on:
         options:
           - eslint-plugin-svelte
           - language-tools
+          - mdsvex
           - prettier-plugin-svelte
           - rollup-plugin-svelte
+          - skeleton
           - svelte-loader
           - svelte-preprocess
           - sveltekit

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -40,6 +40,7 @@ on:
           - prettier-plugin-svelte
           - rollup-plugin-svelte
           - skeleton
+          - svelte-eslint-parser
           - svelte-loader
           - svelte-preprocess
           - sveltekit

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -42,8 +42,10 @@ jobs:
         suite:
           - eslint-plugin-svelte
           - language-tools
+          - mdsvex
           - prettier-plugin-svelte
           - rollup-plugin-svelte
+          - skeleton
           - svelte-loader
           - svelte-preprocess
           - sveltekit

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -46,6 +46,7 @@ jobs:
           - prettier-plugin-svelte
           - rollup-plugin-svelte
           - skeleton
+          - svelte-eslint-parser
           - svelte-loader
           - svelte-preprocess
           - sveltekit

--- a/builds/language-tools.ts
+++ b/builds/language-tools.ts
@@ -1,0 +1,15 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function build(options: RunOptions) {
+	return runInRepo({
+		...options,
+		repo: 'sveltejs/language-tools',
+		branch: 'master',
+		build: 'build',
+	})
+}
+
+export const packages = {
+	'svelte-check': 'packages/svelte-check',
+}

--- a/builds/rollup-plugin-svelte.ts
+++ b/builds/rollup-plugin-svelte.ts
@@ -1,0 +1,14 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function build(options: RunOptions) {
+	return runInRepo({
+		...options,
+		repo: 'sveltejs/rollup-plugin-svelte',
+		branch: 'master',
+	})
+}
+
+export const packages = {
+	'rollup-plugin-svelte': '.',
+}

--- a/ecosystem-ci.ts
+++ b/ecosystem-ci.ts
@@ -17,7 +17,9 @@ const cli = cac()
 cli
 	.command('[...suites]', 'build svelte and run selected suites')
 	.option('--verify', 'verify checkouts by running tests', { default: false })
-	.option('--repo <repo>', 'svelte repository to use', { default: 'sveltejs/svelte' })
+	.option('--repo <repo>', 'svelte repository to use', {
+		default: 'sveltejs/svelte',
+	})
 	.option('--branch <branch>', 'svelte branch to use', { default: 'version-4' })
 	.option('--tag <tag>', 'svelte tag to use')
 	.option('--commit <commit>', 'svelte commit sha to use')
@@ -52,7 +54,9 @@ cli
 	.option('--verify', 'verify svelte checkout by running tests', {
 		default: false,
 	})
-	.option('--repo <repo>', 'svelte repository to use', { default: 'sveltejs/svelte' })
+	.option('--repo <repo>', 'svelte repository to use', {
+		default: 'sveltejs/svelte',
+	})
 	.option('--branch <branch>', 'svelte branch to use', { default: 'main' })
 	.option('--tag <tag>', 'svelte tag to use')
 	.option('--commit <commit>', 'svelte commit sha to use')
@@ -69,7 +73,9 @@ cli
 		'verify checkout by running tests before using local svelte',
 		{ default: false },
 	)
-	.option('--repo <repo>', 'svelte repository to use', { default: 'sveltejs/svelte' })
+	.option('--repo <repo>', 'svelte repository to use', {
+		default: 'sveltejs/svelte',
+	})
 	.option('--release <version>', 'svelte release to use from npm registry')
 	.action(async (suites, options: CommandOptions) => {
 		const { root, sveltePath, workspace } = await setupEnvironment()
@@ -93,7 +99,9 @@ cli
 	)
 	.option('--good <ref>', 'last known good ref, e.g. a previous tag. REQUIRED!')
 	.option('--verify', 'verify checkouts by running tests', { default: false })
-	.option('--repo <repo>', 'svelte repository to use', { default: 'sveltejs/svelte' })
+	.option('--repo <repo>', 'svelte repository to use', {
+		default: 'sveltejs/svelte',
+	})
 	.option('--branch <branch>', 'svelte branch to use', { default: 'version-4' })
 	.option('--tag <tag>', 'svelte tag to use')
 	.option('--commit <commit>', 'svelte commit sha to use')

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "*": [
       "prettier --write --ignore-unknown"
     ],
-    "**/*.js": [
+    "*.ts": [
       "eslint"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "eslint"
     ]
   },
-  "packageManager": "pnpm@8.4.0",
+  "packageManager": "pnpm@8.6.0",
   "type": "module",
   "engines": {
     "node": ">=18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   '@actions/core':

--- a/tests/_carbon-components-svelte.ts
+++ b/tests/_carbon-components-svelte.ts
@@ -1,0 +1,16 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'carbon-design-system/carbon-components-svelte',
+		branch: 'master',
+		build: 'build:lib',
+		overrides: {
+			'rollup-plugin-svelte': true,
+			'svelte-check': true,
+		},
+		test: 'test:types',
+	})
+}

--- a/tests/_carbon-components-svelte.ts
+++ b/tests/_carbon-components-svelte.ts
@@ -7,10 +7,10 @@ export async function test(options: RunOptions) {
 		repo: 'carbon-design-system/carbon-components-svelte',
 		branch: 'master',
 		build: 'build:lib',
+		test: 'test:types',
 		overrides: {
 			'rollup-plugin-svelte': true,
-			'svelte-check': true,
+			'svelte-check': 'latest', // should be true but building it is currently broken
 		},
-		test: 'test:types',
 	})
 }

--- a/tests/_selftest.ts
+++ b/tests/_selftest.ts
@@ -17,7 +17,7 @@ export async function test(options: RunOptions) {
 				)
 			}
 			pkg.scripts.selftestscript =
-				"[ -f ../../svelte/compiler.cjs ] || (echo 'svelte build failed' && exit 1)"
+				"[ -f ../../svelte/packages/svelte/compiler.cjs ] || (echo 'svelte build failed' && exit 1)"
 			await fs.promises.writeFile(
 				pkgFile,
 				JSON.stringify(pkg, null, 2),

--- a/tests/mdsvex.ts
+++ b/tests/mdsvex.ts
@@ -1,0 +1,12 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'pngwn/MDsveX',
+		branch: 'master',
+		build: 'pnpm -r build',
+		test: 'pnpm test',
+	})
+}

--- a/tests/skeleton.ts
+++ b/tests/skeleton.ts
@@ -1,0 +1,16 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'skeletonlabs/skeleton',
+		branch: 'dev',
+		test: ['test', 'check'].map(
+			(script) => `pnpm --dir packages/skeleton ${script}`,
+		),
+		overrides: {
+			'svelte-check': 'latest', // needed for svelte-4, should be `true` but language-tools build still fails
+		},
+	})
+}

--- a/tests/svelte-eslint-parser.ts
+++ b/tests/svelte-eslint-parser.ts
@@ -1,0 +1,12 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'sveltejs/svelte-eslint-parser',
+		branch: 'main',
+		build: 'build',
+		test: 'test',
+	})
+}


### PR DESCRIPTION
### mdsvex

it runs test first an then build in it's own ci, but switching it around still works

### skeleton ui

tests are only in packages/skeleton, needs override for svelte-check

### carbon components

disabled from automations for now (using the _ prefix) because it doesn't work. sveld seems to be stuck. Maybe adding sveld first would be a better idea?