### PR TITLE
replace version-4 branch with master

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -17,7 +17,7 @@ on:
         description: "svelte branch to use"
         required: true
         type: string
-        default: "version-4"
+        default: "master"
       repo:
         description: "svelte repository to use"
         required: true

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -23,7 +23,7 @@ on:
         description: "svelte ref to use"
         required: true
         type: string
-        default: "version-4"
+        default: "master"
       repo:
         description: "svelte repository to use"
         required: true

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -25,7 +25,7 @@ on:
         description: "svelte ref to use"
         required: true
         type: string
-        default: "version-4"
+        default: "master"
       repo:
         description: "svelte repository to use"
         required: true
@@ -68,7 +68,7 @@ jobs:
       - run: pnpm i --frozen-lockfile
       - run: >-
           pnpm tsx ecosystem-ci.ts
-          --${{ inputs.refType || github.event.client_payload.refType || 'branch' }} ${{ inputs.ref || github.event.client_payload.ref || 'version-4' }}
+          --${{ inputs.refType || github.event.client_payload.refType || 'branch' }} ${{ inputs.ref || github.event.client_payload.ref || 'master' }}
           --repo ${{ inputs.repo || github.event.client_payload.repo || 'sveltejs/svelte' }}
           ${{ matrix.suite }}
         id: ecosystem-ci-run
@@ -77,7 +77,7 @@ jobs:
         env:
           WORKFLOW_NAME: ci
           REF_TYPE: ${{ inputs.refType || github.event.client_payload.refType || 'branch' }}
-          REF: ${{ inputs.ref || github.event.client_payload.ref || 'version-4' }}
+          REF: ${{ inputs.ref || github.event.client_payload.ref || 'master' }}
           REPO: ${{ inputs.repo || github.event.client_payload.repo || 'sveltejs/svelte' }}
           SUITE: ${{ matrix.suite }}
           STATUS: ${{ job.status }}

--- a/ecosystem-ci.ts
+++ b/ecosystem-ci.ts
@@ -20,7 +20,7 @@ cli
 	.option('--repo <repo>', 'svelte repository to use', {
 		default: 'sveltejs/svelte',
 	})
-	.option('--branch <branch>', 'svelte branch to use', { default: 'version-4' })
+	.option('--branch <branch>', 'svelte branch to use', { default: 'master' })
 	.option('--tag <tag>', 'svelte tag to use')
 	.option('--commit <commit>', 'svelte commit sha to use')
 	.option('--release <version>', 'svelte release to use from npm registry')
@@ -102,7 +102,7 @@ cli
 	.option('--repo <repo>', 'svelte repository to use', {
 		default: 'sveltejs/svelte',
 	})
-	.option('--branch <branch>', 'svelte branch to use', { default: 'version-4' })
+	.option('--branch <branch>', 'svelte branch to use', { default: 'master' })
 	.option('--tag <tag>', 'svelte tag to use')
 	.option('--commit <commit>', 'svelte commit sha to use')
 	.action(async (suites, options: CommandOptions & { good: string }) => {

--- a/utils.ts
+++ b/utils.ts
@@ -276,7 +276,7 @@ export async function setupSvelteRepo(options: Partial<RepoOptions>) {
 	await setupRepo({
 		repo,
 		dir: sveltePath,
-		branch: 'version-4', // TODO switch to master after version-4 has moved there
+		branch: 'master',
 		shallow: true,
 		...options,
 	})


### PR DESCRIPTION
opening a new PR tries to send it to https://github.com/vitejs/vite-ecosystem-ci. you think there's a setting you can tweak to stop that? (btw, @antony the same thing happens on https://github.com/sveltejs/eslint-config - it tries to send it to the beyonk one since that's where it's forked from)