### PR TITLE
feat: Add @tanstack/svelte-query

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -41,6 +41,7 @@ on:
           - svelte-loader
           - svelte-preprocess
           - sveltekit
+          - tanstack-query
           - vite-plugin-svelte
 jobs:
   init:
@@ -114,6 +115,7 @@ jobs:
           - svelte-loader
           - svelte-preprocess
           - sveltekit
+          - tanstack-query
           - vite-plugin-svelte
       fail-fast: false
     steps:

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -46,6 +46,7 @@ on:
           - svelte-loader
           - svelte-preprocess
           - sveltekit
+          - tanstack-query
           - vite-plugin-svelte
 
 jobs:

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -52,6 +52,7 @@ jobs:
           - svelte-loader
           - svelte-preprocess
           - sveltekit
+          - tanstack-query
           - vite-plugin-svelte
       fail-fast: false
     steps:

--- a/tests/tanstack-query.ts
+++ b/tests/tanstack-query.ts
@@ -6,7 +6,7 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'TanStack/query',
 		branch: 'main',
-		test: 'pnpm nx run-many -t test:lib -p @tanstack/svelte-query',
-		build: 'pnpm nx run-many -t build -p @tanstack/svelte-query',
+		test: 'pnpm nx run-many -t test:lib -p @tanstack/svelte-query --skip-nx-cache',
+		build: 'pnpm nx run-many -t build -p @tanstack/svelte-query --skip-nx-cache',
 	})
 }

--- a/tests/tanstack-query.ts
+++ b/tests/tanstack-query.ts
@@ -1,0 +1,12 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'TanStack/query',
+		branch: 'main',
+		test: 'pnpm pnpm nx run-many -t test:lib -p @tanstack/svelte-query',
+		build: 'pnpm pnpm nx run-many -t build -p @tanstack/svelte-query',
+	})
+}

--- a/tests/tanstack-query.ts
+++ b/tests/tanstack-query.ts
@@ -6,7 +6,7 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'TanStack/query',
 		branch: 'main',
-		test: 'pnpm pnpm nx run-many -t test:lib -p @tanstack/svelte-query',
-		build: 'pnpm pnpm nx run-many -t build -p @tanstack/svelte-query',
+		test: 'pnpm nx run-many -t test:lib -p @tanstack/svelte-query',
+		build: 'pnpm nx run-many -t build -p @tanstack/svelte-query',
 	})
 }


### PR DESCRIPTION
Hoping this config will allow @tanstack/svelte-query to test and build - the monorepo uses Nx, so this command should hopefully tell Nx to only build @tanstack/query-core and @tanstack/svelte-query.