### PR TITLE
fix: Overrides SvelteKit version to v1 for the `melt-ui` test

### DIFF
--- a/tests/melt-ui.ts
+++ b/tests/melt-ui.ts
@@ -7,5 +7,8 @@ export async function test(options: RunOptions) {
 		repo: 'melt-ui/melt-ui',
 		branch: 'develop',
 		test: 'pnpm test',
+		overrides: {
+			'@sveltejs/kit': '^1.22.0', // needed until melt upgrades to SK v2
+		},
 	})
 }


### PR DESCRIPTION
This PR adds a temporary override, pinning SvelteKit to v1 until Melt upgrades to SK v2. If temporarily pinning the version goes against the concept of ecosystem-ci, please feel free to close!

---
It looks like Melt keeps failing because it hasn't been upgraded to SK v2 yet. The current error shown in CI is due to this change: https://discord.com/channels/457912077277855764/1185088342929449080/1185230781359063040 which I've now reverted.

However, another error has cropped back up (the same error that presented in the linked discord thread above). While testing ecosystem-ci locally, I'm noticing that we're _now_ failing due to  `import { vitePreprocess } from '@sveltejs/kit/vite';` no longer being a valid export as it was removed in SK v2. 

The interesting bit is that Skeleton is still passing despite not being on SK v2 either. This leads me to believe that the dependencies for Skeleton aren't being replaced like they are for Melt. My best guess as to why that is is that Skeleton is in a monorepo and Melt isn't. 

To test that this isn't just an isolated incident, I also added `bits-ui` and `svelte-ux` locally to see how they would hold up comparatively. `bits-ui` errored, just like Melt, and `svelte-ux` didn't, just like Skeleton. Both, Skeleton and `svelte-ux` use monorepos, while `bits-ui` and Melt do not.

Edit: Raised an issue for the monorepo deps discrepancy as this behavior doesn't seem to be intended.