### PR TITLE
chore: update skeleton to current repo layout

### DIFF
--- a/tests/skeleton.ts
+++ b/tests/skeleton.ts
@@ -5,12 +5,15 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'skeletonlabs/skeleton',
-		branch: 'dev',
+		branch: 'main',
+		build: 'pnpm --dir packages/skeleton-svelte build',
 		test: ['test', 'check'].map(
-			(script) => `pnpm --dir packages/skeleton ${script}`,
+			(script) => `pnpm --dir packages/skeleton-svelte ${script}`,
 		),
 		overrides: {
-			'svelte-check': 'latest', // needed for svelte-4, should be `true` but language-tools build still fails
+			'svelte-check': true,
+			'@sveltejs/kit': true,
+			'@sveltejs/vite-plugin-svelte': true,
 		},
 	})
 }


### PR DESCRIPTION
this has an issue when installing deps, seems like the `catalog:` feature or sth else messes with the peer dependency declaration. on install.

