### PR TITLE
fix: support pnpm catalogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "@actions/core": "^1.11.1",
     "cac": "^6.7.14",
     "execa": "^9.5.2",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "yaml": "^2.8.0"
   },
   "devDependencies": {
     "@antfu/ni": "^24.3.0",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
       "eslint --fix"
     ]
   },
-  "packageManager": "pnpm@10.2.1",
+  "packageManager": "pnpm@10.12.4",
   "type": "module",
   "engines": {
     "node": ">=22",
-    "pnpm": "^10.2.1"
+    "pnpm": "^10.12.4"
   },
   "repository": {
     "type": "git",
@@ -44,8 +44,7 @@
     "@actions/core": "^1.11.1",
     "cac": "^6.7.14",
     "execa": "^9.5.2",
-    "node-fetch": "^3.3.2",
-    "yaml": "^2.8.0"
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "@antfu/ni": "^24.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
+      yaml:
+        specifier: ^2.8.0
+        version: 2.8.0
     devDependencies:
       '@antfu/ni':
         specifier: ^24.3.0
@@ -1045,9 +1048,9 @@ packages:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
 
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
+  yaml@2.8.0:
+    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+    engines: {node: '>= 14.6'}
     hasBin: true
 
   yocto-queue@0.1.0:
@@ -1725,7 +1728,7 @@ snapshots:
       micromatch: 4.0.8
       pidtree: 0.6.0
       string-argv: 0.3.2
-      yaml: 2.7.1
+      yaml: 2.8.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1973,7 +1976,7 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.0
 
-  yaml@2.7.1: {}
+  yaml@2.8.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ importers:
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
-      yaml:
-        specifier: ^2.8.0
-        version: 2.8.0
     devDependencies:
       '@antfu/ni':
         specifier: ^24.3.0

--- a/tests/skeleton.ts
+++ b/tests/skeleton.ts
@@ -7,6 +7,7 @@ export async function test(options: RunOptions) {
 		repo: 'skeletonlabs/skeleton',
 		branch: 'main',
 		build: 'pnpm --dir packages/skeleton-svelte build',
+		beforeTest: 'pnpm --dir packages/skeleton-svelte exec playwright install',
 		test: ['test', 'check'].map(
 			(script) => `pnpm --dir packages/skeleton-svelte ${script}`,
 		),

--- a/tests/skeleton.ts
+++ b/tests/skeleton.ts
@@ -5,12 +5,15 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'skeletonlabs/skeleton',
-		branch: 'dev',
+		branch: 'main',
+		build: 'pnpm --dir packages/skeleton-svelte build',
 		test: ['test', 'check'].map(
-			(script) => `pnpm --dir packages/skeleton ${script}`,
+			(script) => `pnpm --dir packages/skeleton-svelte ${script}`,
 		),
 		overrides: {
-			'svelte-check': 'latest', // needed for svelte-4, should be `true` but language-tools build still fails
+			'svelte-check': true,
+			'@sveltejs/kit': true,
+			'@sveltejs/vite-plugin-svelte': true,
 		},
 	})
 }

--- a/tests/skeleton.ts
+++ b/tests/skeleton.ts
@@ -7,7 +7,6 @@ export async function test(options: RunOptions) {
 		repo: 'skeletonlabs/skeleton',
 		branch: 'main',
 		build: 'pnpm --dir packages/skeleton-svelte build',
-		beforeTest: 'pnpm --dir packages/skeleton-svelte exec playwright install',
 		test: ['test', 'check'].map(
 			(script) => `pnpm --dir packages/skeleton-svelte ${script}`,
 		),

--- a/tests/skeleton.ts
+++ b/tests/skeleton.ts
@@ -10,10 +10,5 @@ export async function test(options: RunOptions) {
 		test: ['test', 'check'].map(
 			(script) => `pnpm --dir packages/skeleton-svelte ${script}`,
 		),
-		overrides: {
-			'svelte-check': true,
-			'@sveltejs/kit': true,
-			'@sveltejs/vite-plugin-svelte': true,
-		},
 	})
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
 		"esModuleInterop": true,
 		"useUnknownInCatchVariables": false,
 		"allowSyntheticDefaultImports": true,
+		"resolveJsonModule": true,
 		"lib": ["esnext"],
 		"sourceMap": true
 	}


### PR DESCRIPTION
alternate of #31

enforces the use of ecosystem-ci's package manager version in tested repos, as long as the pm's are within the same major