### PR TITLE
fix: update to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ^22.14.0
+          node-version: ^24.11.1
       - run: corepack enable
       - run: pnpm --version
       - uses: actions/setup-node@v4
         with:
-          node-version: ^22.14.0
+          node-version: ^24.11.1
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: install

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ^22.14.0
+          node-version: ^24.11.1
       - run: corepack enable
       - run: pnpm --version
       - run: pnpm i --frozen-lockfile
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ^22.14.0
+          node-version: ^24.11.1
       - run: corepack enable
       - run: pnpm --version
       - run: pnpm i --frozen-lockfile

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ^22.14.0
+          node-version: ^24.11.1
         id: setup-node
       - run: corepack enable
       - run: pnpm --version

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ^22.14.0
+          node-version: ^24.11.1
         id: setup-node
       - run: corepack enable
       - run: pnpm --version


### PR DESCRIPTION
This will hopefully fix Skeleton
```
/home/runner/work/svelte-ecosystem-ci/svelte-ecosystem-ci/workspace/skeleton/skeleton $> pnpm install --prefer-frozen-lockfile --strict-peer-dependencies false
  ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-10.24.0.tgz
   ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
  
  Your Node version is incompatible with "/home/runner/work/svelte-ecosystem-ci/svelte-ecosystem-ci/workspace/skeleton/skeleton".
  
  Expected version: 24.11.1
  Got: v22.21.1
  
  This is happening because the package's manifest has an engines.node field specified.
  To fix this issue, install the required Node version.
```