### PR TITLE
fix: change names from `master` to `main`

### DIFF
--- a/builds/rollup-plugin-svelte.ts
+++ b/builds/rollup-plugin-svelte.ts
@@ -5,7 +5,7 @@ export async function build(options: RunOptions) {
 	return runInRepo({
 		...options,
 		repo: 'sveltejs/rollup-plugin-svelte',
-		branch: 'master',
+		branch: 'main',
 	})
 }
 

--- a/tests/prettier-plugin-svelte.ts
+++ b/tests/prettier-plugin-svelte.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'sveltejs/prettier-plugin-svelte',
-		branch: 'master',
+		branch: 'main',
 		build: 'build',
 		test: 'test',
 	})

--- a/tests/rollup-plugin-svelte.ts
+++ b/tests/rollup-plugin-svelte.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'sveltejs/rollup-plugin-svelte',
-		branch: 'master',
+		branch: 'main',
 		test: 'test',
 	})
 }


### PR DESCRIPTION
This PR fixes the `prettier-plugin-svelte` and `rollup-plugin-svelte` tests which changed their default branch names recently.