### PR TITLE
chore: move pnpm settings to `pnpm-workspace.yaml`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,19 +60,5 @@
     "tsx": "^4.19.3",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.31.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "cross-spawn@>=7.0.0 <7.0.5": "^7.0.6"
-    },
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "simple-git-hooks"
-    ],
-    "auditConfig": {
-      "ignoreGhsas": [
-        "GHSA-67mh-4wv8-2f99"
-      ]
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+auditConfig:
+  ignoreGhsas:
+    - GHSA-67mh-4wv8-2f99
+onlyBuiltDependencies:
+  - esbuild
+  - simple-git-hooks
+overrides:
+  cross-spawn@>=7.0.0 <7.0.5: ^7.0.6


### PR DESCRIPTION
pnpm says the settings in package.json will be ignored so I moved them to where they should be. This probably helps when we eventually use pnpm 11 too

> [WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides", "pnpm.onlyBuiltDependencies", "pnpm.auditConfig". See https://pnpm.io/settings for the new home of each setting.