### PR TITLE
fix: add `@sveltejs/load-config` overrides

### DIFF
--- a/builds/language-tools.ts
+++ b/builds/language-tools.ts
@@ -12,5 +12,6 @@ export async function build(options: RunOptions) {
 }
 
 export const packages = {
+	'@sveltejs/load-config': 'packages/load-config',
 	'svelte-check': 'packages/svelte-check',
 }

--- a/tests/bits-ui.ts
+++ b/tests/bits-ui.ts
@@ -12,6 +12,7 @@ export async function test(options: RunOptions) {
 			'@sveltejs/vite-plugin-svelte': false, // bits-ui uses older Vite version which our newest v-p-s isn't compabitle with
 			'@sveltejs/vite-plugin-svelte-inspector': false,
 			'@sveltejs/kit': true,
+			'@sveltejs/load-config': true,
 			'svelte-check': true,
 		},
 	})

--- a/tests/layerchart.ts
+++ b/tests/layerchart.ts
@@ -11,6 +11,7 @@ export async function test(options: RunOptions) {
 			'@sveltejs/vite-plugin-svelte': true,
 			'@sveltejs/vite-plugin-svelte-inspector': true,
 			'@sveltejs/kit': true,
+			'@sveltejs/load-config': true,
 			'svelte-check': true,
 		},
 	})

--- a/tests/sveltekit.ts
+++ b/tests/sveltekit.ts
@@ -8,6 +8,7 @@ export async function test(options: RunOptions) {
 		overrides: {
 			'@sveltejs/vite-plugin-svelte': true,
 			'@sveltejs/vite-plugin-svelte-inspector': true,
+			'@sveltejs/load-config': true,
 			'svelte-check': true,
 		},
 		beforeTest: 'pnpm playwright install',

--- a/tests/vite-plugin-svelte.ts
+++ b/tests/vite-plugin-svelte.ts
@@ -8,6 +8,7 @@ export async function test(options: RunOptions) {
 		beforeTest: 'pnpm playwright install chromium',
 		test: ['check:lint', 'check:types', 'test'],
 		overrides: {
+			'@sveltejs/load-config': true,
 			'svelte-check': true,
 			'@sveltejs/kit': true,
 		},


### PR DESCRIPTION
new dependency which svelte-check depends on