### PR TITLE
fix: update layerchart scripts

### DIFF
--- a/tests/layerchart.ts
+++ b/tests/layerchart.ts
@@ -5,8 +5,11 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'techniq/layerchart',
-		build: 'pnpm build:examples',
-		test: 'pnpm --dir packages/layerchart test:unit',
+		build: 'pnpm --dir packages/layerchart build',
+		test: [
+			'pnpm --dir packages/layerchart test:unit',
+			'pnpm --dir packages/layerchart test:ui',
+		],
 		overrides: {
 			'@sveltejs/vite-plugin-svelte': true,
 			'@sveltejs/kit': true,

--- a/tests/layerchart.ts
+++ b/tests/layerchart.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'techniq/layerchart',
-		build: 'pnpm build',
+		build: 'pnpm build:examples',
 		test: 'pnpm --dir packages/layerchart test:unit',
 		overrides: {
 			'@sveltejs/vite-plugin-svelte': true,


### PR DESCRIPTION
Ecosystem CI currently fails because layerchart no longer has a `build` script. This PR updates the scripts to use layerchart's latest which separates them into specific scripts:
1. `build` -> `build:packages` and `build:examples`
2. `test` -> `test:unit` and `test:ui`

Afaik we only want to build the layerchart package and run its tests while ignoring the bundle analyser, docs, and examples.