### PR TITLE
fix: install Playwright for layerchart `test:ui` in CI

### DIFF
--- a/tests/layerchart.ts
+++ b/tests/layerchart.ts
@@ -5,6 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'techniq/layerchart',
+		beforeTest: 'pnpm playwright install',
 		build: 'pnpm --dir packages/layerchart build',
 		test: [
 			'pnpm --dir packages/layerchart test:unit',


### PR DESCRIPTION
This PR installs `playwright` before running `test:ui` which is needed by Vitest