### PR TITLE
fix: specify working directory before `pnpm playwright install`

### DIFF
--- a/tests/layerchart.ts
+++ b/tests/layerchart.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'techniq/layerchart',
-		beforeTest: 'pnpm playwright install',
+		beforeTest: 'pnpm --dir packages/layerchart playwright install',
 		build: 'pnpm --dir packages/layerchart build',
 		test: [
 			'pnpm --dir packages/layerchart test:unit',


### PR DESCRIPTION
Ok this should be it: `pnpm playwright` needs to be run from the `packages/layerchart` directory because that's where `playwright` is installed.