### PR TITLE
fix: switch SvelteKit branch to `version-3`

### DIFF
--- a/tests/sveltekit.ts
+++ b/tests/sveltekit.ts
@@ -5,6 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'sveltejs/kit',
+		branch: 'version-3',
 		overrides: {
 			'@sveltejs/vite-plugin-svelte': true,
 			'@sveltejs/load-config': true,


### PR DESCRIPTION
Fixes ecosystem test but we'll have to switch it back when SvelteKit 3 is `main`